### PR TITLE
Change PollingZMQContext::poll to empty the socket queue rather than poll once per interval

### DIFF
--- a/include/nzmqt/nzmqt.hpp
+++ b/include/nzmqt/nzmqt.hpp
@@ -620,7 +620,11 @@ namespace nzmqt
             if (m_stopped)
                 return;
 
-            poll();
+            try {
+                poll();
+            } catch (ZMQException e) {
+		qWarning("Exception during poll: %s\n", e.what());
+            }
 
             if (!m_stopped)
                 QTimer::singleShot(m_interval, this, SLOT(run()));


### PR DESCRIPTION
With the way the poll was set up, if your interval was 10ms (default), you
would only get a maximum of 100 messages per socket as poll will only take the
first message from each available socket.  This was not nearly enough for my
use where the peak is into the thousands per second on a socket, so I have
modified the code to repeatedly poll while there is still data to poll.

This should empty the socket queue before returning to singleShot delay again.
