### PR TITLE
Fix occasional incorrect result from hasMoreMessageParts

### DIFF
--- a/include/nzmqt/nzmqt.hpp
+++ b/include/nzmqt/nzmqt.hpp
@@ -361,7 +361,7 @@ namespace nzmqt
         // to be received.
         inline bool hasMoreMessageParts() const
         {
-            quint64 value;
+            int value;
             size_t size = sizeof(value);
             getOption(OPT_RCVMORE, &value, &size);
             return value;


### PR DESCRIPTION
On occasion, hasMoreMessageParts would return true when the message did not, in fact, have any more parts. The result would be a thrown exception, as `recv()` was called on a REQ socket that had no waiting messages. The problem seemed to be caused by passing a `quint64` to the `zmq_getsockopt` function. Since the man page for `zmq_getsockopt` said the value type for `ZMQ_RCVMORE` was `int`, I changed the quint64 to `int` and that seemed to solve the problem.

I've tested on 2 systems with the same code and neither have exhibited the problem since the change.
