### PR TITLE
Support type-safe Qt 5 singals & slots connections

### DIFF
--- a/include/nzmqt/nzmqt.hpp
+++ b/include/nzmqt/nzmqt.hpp
@@ -431,6 +431,9 @@ namespace nzmqt
             setOption(OPT_UNSUBSCRIBE, filter_);
         }
 
+    signals:
+        void messageReceived(const QList<QByteArray>&);
+
     protected:
         ZMQSocket(ZMQContext* context_, Type type_);
 
@@ -600,9 +603,6 @@ namespace nzmqt
         {
             emit messageReceived(message);
         }
-
-    signals:
-        void messageReceived(const QList<QByteArray>&);
     };
 
     class PollingZMQContext : public ZMQContext, public QRunnable
@@ -833,9 +833,6 @@ namespace nzmqt
 //                socketNotifyWrite_->setEnabled(false);
 //            }
 //        }
-
-    signals:
-        void messageReceived(const QList<QByteArray>&);
 
     private:
         QSocketNotifier *socketNotifyRead_;


### PR DESCRIPTION
New Qt5 Signals & Slots (http://qt-project.org/doc/qt-5.0/qtcore/signalsandslots.html) need the messageReceived signal only in the base class.

This way next example can be done :

``` c++
nzmqt::ZMQContext* context = nzmqt::createDefaultContext( this );
nzmqt::ZMQSocket* input = context->createSocket( nzmqt::ZMQSocket::TYP_SUB, this );
input->subscribeTo( "topic" );
QObject::connect( input, &nzmqt::ZMQSocket::messageReceived, &myObject, &myObject::myMagic );
//or even lambda functions can be used
QObject::connect( input, &nzmqt::ZMQSocket::messageReceived, [=](const QList<QByteArray>& data){ doMagic(data); } );
```
