### PR TITLE
change the signal when have data

### DIFF
--- a/include/nzmqt/impl.hpp
+++ b/include/nzmqt/impl.hpp
@@ -1,4 +1,4 @@
-// Copyright 2011-2014 Johann Duscher (a.k.a. Jonny Dee). All rights reserved.
+﻿// Copyright 2011-2014 Johann Duscher (a.k.a. Jonny Dee). All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
@@ -218,6 +218,7 @@ NZMQT_INLINE QList<QByteArray> ZMQSocket::receiveMessage()
     ZMQMessage msg;
     while (receiveMessage(&msg))
     {
+//        qDebug() << msg.toByteArray();
         parts += msg.toByteArray();
         msg.rebuild();
 
@@ -421,10 +422,10 @@ NZMQT_INLINE PollingZMQSocket::PollingZMQSocket(PollingZMQContext* context_, Typ
 {
 }
 
-NZMQT_INLINE void PollingZMQSocket::onMessageReceived(const QList<QByteArray>& message)
-{
-    emit messageReceived(message);
-}
+//NZMQT_INLINE void PollingZMQSocket::onMessageReceived(const QList<QByteArray>& message)
+//{
+//    emit messageReceived(message);
+//}
 
 
 
@@ -508,8 +509,10 @@ NZMQT_INLINE void PollingZMQContext::poll(long timeout_)
             if (poIt->revents & ZMQSocket::EVT_POLLIN)
             {
                 PollingZMQSocket* socket = static_cast<PollingZMQSocket*>(*soIt);
-                QList<QByteArray> message = socket->receiveMessage();
-                socket->onMessageReceived(message);
+//                QList<QByteArray> message = socket->receiveMessage();
+////                qDebug() << message;
+//                socket->onMessageReceived(message);
+                emit socket->readyRead();
                 i++;
             }
             ++soIt;
@@ -591,8 +594,9 @@ NZMQT_INLINE void SocketNotifierZMQSocket::socketReadActivity()
 
     while(events() & EVT_POLLIN)
     {
-        QList<QByteArray> message = receiveMessage();
-        emit messageReceived(message);
+//        QList<QByteArray> message = receiveMessage();
+//        emit messageReceived(message);
+        emit readyRead();
     }
 
     socketNotifyRead_->setEnabled(true);

--- a/include/nzmqt/nzmqt.hpp
+++ b/include/nzmqt/nzmqt.hpp
@@ -1,4 +1,4 @@
-// Copyright 2011-2014 Johann Duscher (a.k.a. Jonny Dee). All rights reserved.
+﻿// Copyright 2011-2014 Johann Duscher (a.k.a. Jonny Dee). All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
@@ -269,7 +269,8 @@ namespace nzmqt
         void unsubscribeFrom(const QByteArray& filter_);
 
     signals:
-        void messageReceived(const QList<QByteArray>&);
+//        void messageReceived(const QList<QByteArray>&);
+        void readyRead();
 
     public slots:
         void close();
@@ -383,7 +384,7 @@ namespace nzmqt
 
         // This method is called by the socket's context object in order
         // to signal a new received message.
-        void onMessageReceived(const QList<QByteArray>& message);
+//        void onMessageReceived(const QList<QByteArray>& message);
     };
 
     class NZMQT_API PollingZMQContext : public ZMQContext, public QRunnable

--- a/src/nzmqt_sharedlib.pro
+++ b/src/nzmqt_sharedlib.pro
@@ -65,3 +65,15 @@ OTHER_FILES += \
     ../LICENSE.header \
     ../CHANGELOG.md \
     ../LICENSE.md
+
+
+
+#win32:CONFIG(release, debug|release): LIBS += -L$$PWD/../../../../../Libs/ZEROMQ/lib/ -llibzmq
+#else:win32:CONFIG(debug, debug|release): LIBS += -L$$PWD/../../../../../Libs/ZEROMQ/lib/ -llibzmq_d
+
+#INCLUDEPATH += $$PWD/../../../../../Libs/ZEROMQ/include
+#DEPENDPATH += $$PWD/../../../../../Libs/ZEROMQ/include
+
+
+#INCLUDEPATH += $$PWD/../include
+#DEPENDPATH += $$PWD/../include


### PR DESCRIPTION
change "messageReceived(const QList<QByteArray>&)"  to "readyRead()" .
Because if the poll is not a thread with processing ， then sends the data will be read and written across threads.
I have to use It : https://github.com/dushibaiyu/DsbyLiteExample/tree/master/0mq_Qt_Server
In that, I also change while(cnt > 0) to QTimer::timeout (int poll).
