### PR TITLE
Added pri file to make inclusion into other Qt projects easier

### DIFF
--- a/nzmqt.pri
+++ b/nzmqt.pri
@@ -1,0 +1,18 @@
+# Include this file into your project to build and link
+# the nzmqt library into you application
+
+# This define will "move" nzmqt class method
+# implementations to nzmqt.cpp file.
+DEFINES += NZMQT_LIB
+
+SOURCES += \
+    $$PWD/src/nzmqt/nzmqt.cpp
+
+HEADERS += \
+    $$PWD/include/nzmqt/global.hpp \
+    $$PWD/include/nzmqt/nzmqt.hpp \
+    $$PWD/include/nzmqt/impl.hpp
+
+INCLUDEPATH += \
+    $$PWD/include \
+    $$PWD/3rdparty/cppzmq


### PR DESCRIPTION
The added pri file simplifies the process of adding nzmqt to Qt projects. It is intended to be used for projects that want to include nzqmt statically linked into the application. The approach is similar to the one used by JDNS https://github.com/psi-im/jdns
