### PR TITLE
Added methods to unbind, disconnect and configure high watermarks to ZMQSocket

### DIFF
--- a/include/nzmqt/impl.hpp
+++ b/include/nzmqt/impl.hpp
@@ -171,6 +171,16 @@ NZMQT_INLINE void ZMQSocket::bindTo(const char *addr_)
     bind(addr_);
 }
 
+NZMQT_INLINE void ZMQSocket::unbindFrom(const QString& addr_)
+{
+    unbind(addr_.toLocal8Bit());
+}
+
+NZMQT_INLINE void ZMQSocket::unbindFrom(const char *addr_)
+{
+    unbind(addr_);
+}
+
 NZMQT_INLINE void ZMQSocket::connectTo(const QString& addr_)
 {
     zmqsuper::connect(addr_.toLocal8Bit());
@@ -179,6 +189,16 @@ NZMQT_INLINE void ZMQSocket::connectTo(const QString& addr_)
 NZMQT_INLINE void ZMQSocket::connectTo(const char* addr_)
 {
     zmqsuper::connect(addr_);
+}
+
+NZMQT_INLINE void ZMQSocket::disconnectFrom(const QString& addr_)
+{
+    zmqsuper::disconnect(addr_.toLocal8Bit());
+}
+
+NZMQT_INLINE void ZMQSocket::disconnectFrom(const char* addr_)
+{
+    zmqsuper::disconnect(addr_);
 }
 
 NZMQT_INLINE bool ZMQSocket::sendMessage(ZMQMessage& msg_, SendFlags flags_)
@@ -333,6 +353,16 @@ NZMQT_INLINE void ZMQSocket::unsubscribeFrom(const QString& filter_)
 NZMQT_INLINE void ZMQSocket::unsubscribeFrom(const QByteArray& filter_)
 {
     setOption(OPT_UNSUBSCRIBE, filter_);
+}
+
+NZMQT_INLINE void ZMQSocket::setSendHighWaterMark(int value_)
+{
+    setOption(OPT_SNDHWM, value_);
+}
+
+NZMQT_INLINE void ZMQSocket::setReceiveHighWaterMark(int value_)
+{
+    setOption(OPT_RCVHWM, value_);
 }
 
 

--- a/include/nzmqt/nzmqt.hpp
+++ b/include/nzmqt/nzmqt.hpp
@@ -176,7 +176,9 @@ namespace nzmqt
             OPT_LINGER = ZMQ_LINGER,
             OPT_RECONNECT_IVL = ZMQ_RECONNECT_IVL,
             OPT_RECONNECT_IVL_MAX = ZMQ_RECONNECT_IVL_MAX,
-            OPT_BACKLOG = ZMQ_BACKLOG
+            OPT_BACKLOG = ZMQ_BACKLOG,
+            OPT_SNDHWM = ZMQ_SNDHWM,
+            OPT_RCVHWM = ZMQ_RCVHWM
         };
 
         ~ZMQSocket();
@@ -203,9 +205,17 @@ namespace nzmqt
 
         void bindTo(const char *addr_);
 
+        void unbindFrom(const QString& addr_);
+
+        void unbindFrom(const char *addr_);
+
         void connectTo(const QString& addr_);
 
         void connectTo(const char* addr_);
+
+        void disconnectFrom(const QString& addr_);
+
+        void disconnectFrom(const char* addr_);
 
         bool sendMessage(ZMQMessage& msg_, SendFlags flags_ = SND_NOBLOCK);
 
@@ -256,6 +266,10 @@ namespace nzmqt
         void unsubscribeFrom(const QString& filter_);
 
         void unsubscribeFrom(const QByteArray& filter_);
+
+        void setSendHighWaterMark(int value_);
+
+        void setReceiveHighWaterMark(int value_);
 
     signals:
         void messageReceived(const QList<QByteArray>&);


### PR DESCRIPTION
Extended ZMQSocket to be able to remove a binding, disconnect from an endpoint and configure high watermarks. Nothing fancy, just wrapped zmq's existing functions.
