### PR TITLE
Changed fileDescriptor Type to support win_64

### DIFF
--- a/include/nzmqt/impl.hpp
+++ b/include/nzmqt/impl.hpp
@@ -263,9 +263,9 @@ NZMQT_INLINE QList< QList<QByteArray> > ZMQSocket::receiveMessages()
     return ret;
 }
 
-NZMQT_INLINE qint32 ZMQSocket::fileDescriptor() const
+NZMQT_INLINE qintptr ZMQSocket::fileDescriptor() const
 {
-    qint32 value;
+    qintptr value;
     size_t size = sizeof(value);
     getOption(OPT_FD, &value, &size);
     return value;
@@ -598,7 +598,7 @@ NZMQT_INLINE SocketNotifierZMQSocket::SocketNotifierZMQSocket(ZMQContext* contex
     , socketNotifyRead_(0)
     , socketNotifyWrite_(0)
 {
-    int fd = fileDescriptor();
+    qintptr fd = fileDescriptor();
 
     socketNotifyRead_ = new QSocketNotifier(fd, QSocketNotifier::Read, this);
     QObject::connect(socketNotifyRead_, SIGNAL(activated(int)), this, SLOT(socketReadActivity()));

--- a/include/nzmqt/nzmqt.hpp
+++ b/include/nzmqt/nzmqt.hpp
@@ -235,7 +235,7 @@ namespace nzmqt
         // Note that this method won't work with REQ-REP protocol.
         QList< QList<QByteArray> > receiveMessages();
 
-        qint32 fileDescriptor() const;
+        qintptr fileDescriptor() const;
 
         Events events() const;
 


### PR DESCRIPTION
Changed Type from qint32 to qintptr, which according to QT "Typedef for
either qint32 or qint64. This type is guaranteed to be the same size as
a pointer on all platforms supported by Qt. On a system with 32-bit
pointers, qintptr is a typedef for qint32; on a system with 64-bit
pointers, qintptr is a typedef for qint64." Solution Taken from
http://stackoverflow.com/questions/18607915/zmq-getsockopt-returns-einval-on-windows-x64-when-local-address-of-zmq-fd-option