### PR TITLE
Add braces to various if statements

### DIFF
--- a/include/nzmqt/impl.hpp
+++ b/include/nzmqt/impl.hpp
@@ -219,10 +219,15 @@ NZMQT_INLINE bool ZMQSocket::sendMessage(const QList<QByteArray>& msg_, SendFlag
     for (i = 0; i < msg_.size() - 1; i++)
     {
         if (!sendMessage(msg_[i], flags_ | SND_MORE))
+        {
             return false;
+        }
     }
+
     if (i < msg_.size())
+    {
         return sendMessage(msg_[i], flags_);
+    }
 
     return true;
 }
@@ -243,7 +248,9 @@ NZMQT_INLINE QList<QByteArray> ZMQSocket::receiveMessage(ReceiveFlags flags_)
         msg.rebuild();
 
         if (!hasMoreMessageParts())
+        {
             break;
+        }
     }
 
     return parts;
@@ -504,7 +511,9 @@ NZMQT_INLINE bool PollingZMQContext::isStopped() const
 NZMQT_INLINE void PollingZMQContext::run()
 {
     if (m_stopped)
+    {
         return;
+    }
 
     try
     {
@@ -517,7 +526,9 @@ NZMQT_INLINE void PollingZMQContext::run()
     }
 
     if (!m_stopped)
+    {
         QTimer::singleShot(m_interval, this, SLOT(run()));
+    }
 }
 
 NZMQT_INLINE void PollingZMQContext::poll(long timeout_)
@@ -527,12 +538,16 @@ NZMQT_INLINE void PollingZMQContext::poll(long timeout_)
         QMutexLocker lock(&m_pollItemsMutex);
 
         if (m_pollItems.empty())
+        {
             return;
+        }
 
         cnt = zmq::poll(&m_pollItems[0], m_pollItems.size(), timeout_);
         Q_ASSERT_X(cnt >= 0, Q_FUNC_INFO, "A value < 0 should be reflected by an exception.");
         if (0 == cnt)
+        {
             return;
+        }
 
         PollItems::iterator poIt = m_pollItems.begin();
         ZMQContext::Sockets::const_iterator soIt = registeredSockets().begin();

--- a/src/app/NzmqtApp.hpp
+++ b/src/app/NzmqtApp.hpp
@@ -101,7 +101,9 @@ protected slots:
             if ("pubsub-publisher" == command)
             {
                 if (args.size() < 4)
+                {
                     throw std::runtime_error("Mandatory argument(s) missing!");
+                }
 
                 QString address = args[2];
                 QString topic = args[3];
@@ -110,7 +112,9 @@ protected slots:
             else if ("pubsub-subscriber" == command)
             {
                 if (args.size() < 4)
+                {
                     throw std::runtime_error("Mandatory argument(s) missing!");
+                }
 
                 QString address = args[2];
                 QString topic = args[3];
@@ -119,7 +123,9 @@ protected slots:
             else if ("reqrep-replier" == command)
             {
                 if (args.size() < 4)
+                {
                     throw std::runtime_error("Mandatory argument(s) missing!");
+                }
 
                 QString address = args[2];
                 QString responseMsg = args[3];
@@ -128,7 +134,9 @@ protected slots:
             else if ("reqrep-requester" == command)
             {
                 if (args.size() < 4)
+                {
                     throw std::runtime_error("Mandatory argument(s) missing!");
+                }
 
                 QString address = args[2];
                 QString requestMsg = args[3];
@@ -137,7 +145,9 @@ protected slots:
             else if ("pushpull-ventilator" == command)
             {
                 if (args.size() < 5)
+                {
                     throw std::runtime_error("Mandatory argument(s) missing!");
+                }
 
                 QString ventilatorAddress = args[2];
                 QString sinkAddress = args[3];
@@ -153,7 +163,9 @@ protected slots:
             else if ("pushpull-worker" == command)
             {
                 if (args.size() < 4)
+                {
                     throw std::runtime_error("Mandatory argument(s) missing!");
+                }
 
                 QString ventilatorAddress = args[2];
                 QString sinkAddress = args[3];
@@ -162,7 +174,9 @@ protected slots:
             else if ("pushpull-sink" == command)
             {
                 if (args.size() < 3)
+                {
                     throw std::runtime_error("Mandatory argument(s) missing!");
+                }
 
                 QString sinkAddress = args[2];
                 commandImpl = new pushpull::Sink(*context, sinkAddress, this);

--- a/src/pushpull/Sink.hpp
+++ b/src/pushpull/Sink.hpp
@@ -85,15 +85,21 @@ protected slots:
             batchStarted(numberOfWorkItems_);
 
             if (numberOfWorkItems_)
+            {
                 return;
+            }
         }
 
         if (numberOfWorkItems_ > 0)
         {
             if (numberOfWorkItems_ % 10 == 0)
+            {
                 qDebug() << numberOfWorkItems_;
+            }
             else
+            {
                 qDebug() << ".";
+            }
 
             --numberOfWorkItems_;
             emit workItemResultReceived();


### PR DESCRIPTION
Personally, I find consistency to be important with regards to the usage of braces. When there are bugs in the wild, such as openssl's HeartBleed that are caused by improper brace usage, I think it's wise to always use braces whereever an if statement is used.