### PR TITLE
Collection of mostly cherry-pickable changes related to c++11 features

### DIFF
--- a/include/nzmqt/impl.hpp
+++ b/include/nzmqt/impl.hpp
@@ -84,7 +84,7 @@ NZMQT_INLINE QByteArray ZMQMessage::toByteArray()
  */
 
 NZMQT_INLINE ZMQSocket::ZMQSocket(ZMQContext* context_, Type type_)
-    : qsuper(0)
+    : qsuper(nullptr)
     , zmqsuper(*context_, type_)
     , m_context(context_)
 {
@@ -102,7 +102,7 @@ NZMQT_INLINE void ZMQSocket::close()
     if (m_context)
     {
         m_context->unregisterSocket(this);
-        m_context = 0;
+        m_context = nullptr;
     }
     zmqsuper::close();
 }
@@ -371,7 +371,7 @@ NZMQT_INLINE ZMQContext::~ZMQContext()
 //    qDebug() << Q_FUNC_INFO << "Sockets:" << m_sockets;
     foreach (ZMQSocket* socket, m_sockets)
     {
-        socket->m_context = 0;
+        socket->m_context = nullptr;
         // As stated by 0MQ, close() must ONLY be called from the thread
         // owning the socket. So we use 'invokeMethod' which (hopefully)
         // results in a 'close' call from within the socket's thread.

--- a/include/nzmqt/impl.hpp
+++ b/include/nzmqt/impl.hpp
@@ -587,10 +587,10 @@ NZMQT_INLINE SocketNotifierZMQSocket::SocketNotifierZMQSocket(ZMQContext* contex
     qintptr fd = fileDescriptor();
 
     socketNotifyRead_ = new QSocketNotifier(fd, QSocketNotifier::Read, this);
-    QObject::connect(socketNotifyRead_, SIGNAL(activated(int)), this, SLOT(socketReadActivity()));
+    QObject::connect(socketNotifyRead_, &QSocketNotifier::activated, this, &SocketNotifierZMQSocket::socketReadActivity);
 
     socketNotifyWrite_ = new QSocketNotifier(fd, QSocketNotifier::Write, this);
-    QObject::connect(socketNotifyWrite_, SIGNAL(activated(int)), this, SLOT(socketWriteActivity()));
+    QObject::connect(socketNotifyWrite_, &QSocketNotifier::activated, this, &SocketNotifierZMQSocket::socketWriteActivity);
 }
 
 NZMQT_INLINE SocketNotifierZMQSocket::~SocketNotifierZMQSocket()
@@ -674,8 +674,8 @@ NZMQT_INLINE bool SocketNotifierZMQContext::isStopped() const
 NZMQT_INLINE SocketNotifierZMQSocket* SocketNotifierZMQContext::createSocketInternal(ZMQSocket::Type type_)
 {
     SocketNotifierZMQSocket *socket = new SocketNotifierZMQSocket(this, type_);
-    connect(socket, SIGNAL(notifierError(int,QString)),
-            this, SIGNAL(notifierError(int,QString)));
+    connect(socket, &SocketNotifierZMQSocket::notifierError,
+            this, &SocketNotifierZMQContext::notifierError);
     return socket;
 }
 

--- a/include/nzmqt/impl.hpp
+++ b/include/nzmqt/impl.hpp
@@ -50,21 +50,6 @@ namespace nzmqt
  * ZMQMessage
  */
 
-NZMQT_INLINE ZMQMessage::ZMQMessage()
-    : super()
-{
-}
-
-NZMQT_INLINE ZMQMessage::ZMQMessage(size_t size_)
-    : super(size_)
-{
-}
-
-NZMQT_INLINE ZMQMessage::ZMQMessage(void* data_, size_t size_, free_fn *ffn_, void* hint_)
-    : super(data_, size_, ffn_, hint_)
-{
-}
-
 NZMQT_INLINE ZMQMessage::ZMQMessage(const QByteArray& b)
     : super(b.size())
 {

--- a/include/nzmqt/impl.hpp
+++ b/include/nzmqt/impl.hpp
@@ -117,26 +117,6 @@ NZMQT_INLINE void ZMQSocket::setOption(Option optName_, const QByteArray& bytes_
     setOption(optName_, bytes_.constData(), bytes_.size());
 }
 
-NZMQT_INLINE void ZMQSocket::setOption(Option optName_, qint32 value_)
-{
-    setOption(optName_, &value_, sizeof(value_));
-}
-
-NZMQT_INLINE void ZMQSocket::setOption(Option optName_, quint32 value_)
-{
-    setOption(optName_, &value_, sizeof(value_));
-}
-
-NZMQT_INLINE void ZMQSocket::setOption(Option optName_, qint64 value_)
-{
-    setOption(optName_, &value_, sizeof(value_));
-}
-
-NZMQT_INLINE void ZMQSocket::setOption(Option optName_, quint64 value_)
-{
-    setOption(optName_, &value_, sizeof(value_));
-}
-
 NZMQT_INLINE void ZMQSocket::getOption(Option option_, void *optval_, size_t *optvallen_) const
 {
     const_cast<ZMQSocket*>(this)->getsockopt(option_, optval_, optvallen_);

--- a/include/nzmqt/impl.hpp
+++ b/include/nzmqt/impl.hpp
@@ -61,11 +61,6 @@ NZMQT_INLINE void ZMQMessage::move(ZMQMessage* msg_)
     super::move(static_cast<zmq::message_t*>(msg_));
 }
 
-NZMQT_INLINE void ZMQMessage::copy(ZMQMessage* msg_)
-{
-    super::copy(msg_);
-}
-
 NZMQT_INLINE void ZMQMessage::clone(ZMQMessage* msg_)
 {
     rebuild(msg_->size());

--- a/include/nzmqt/impl.hpp
+++ b/include/nzmqt/impl.hpp
@@ -236,7 +236,7 @@ NZMQT_INLINE QList< QList<QByteArray> > ZMQSocket::receiveMessages(ReceiveFlags 
     QList<QByteArray> parts = receiveMessage(flags_);
     while (!parts.isEmpty())
     {
-        ret += parts;
+        ret += std::move(parts);
 
         parts = receiveMessage(flags_);
     }
@@ -520,8 +520,8 @@ NZMQT_INLINE void PollingZMQContext::poll(long timeout_)
             if (poIt->revents & ZMQSocket::EVT_POLLIN)
             {
                 PollingZMQSocket* socket = static_cast<PollingZMQSocket*>(*soIt);
-                QList<QByteArray> message = socket->receiveMessage();
-                socket->onMessageReceived(message);
+                QList<QByteArray> && message = socket->receiveMessage();
+                socket->onMessageReceived(std::move(message));
                 i++;
             }
             ++soIt;
@@ -606,7 +606,7 @@ NZMQT_INLINE void SocketNotifierZMQSocket::socketReadActivity()
     {
         while(isConnected() && (events() & EVT_POLLIN))
         {
-            QList<QByteArray> message = receiveMessage();
+            const QList<QByteArray> & message = receiveMessage();
             emit messageReceived(message);
         }
     }
@@ -627,7 +627,7 @@ NZMQT_INLINE void SocketNotifierZMQSocket::socketWriteActivity()
     {
         while (isConnected() && (events() & EVT_POLLIN))
         {
-            QList<QByteArray> message = receiveMessage();
+            const QList<QByteArray> & message = receiveMessage();
             emit messageReceived(message);
         }
     }

--- a/include/nzmqt/impl.hpp
+++ b/include/nzmqt/impl.hpp
@@ -364,7 +364,7 @@ NZMQT_INLINE ZMQContext::ZMQContext(QObject* parent_, int io_threads_)
 NZMQT_INLINE ZMQContext::~ZMQContext()
 {
 //    qDebug() << Q_FUNC_INFO << "Sockets:" << m_sockets;
-    foreach (ZMQSocket* socket, m_sockets)
+    for(ZMQSocket* socket : registeredSockets())
     {
         socket->m_context = nullptr;
         // As stated by 0MQ, close() must ONLY be called from the thread
@@ -389,15 +389,13 @@ NZMQT_INLINE void ZMQContext::registerSocket(ZMQSocket* socket_)
 
 NZMQT_INLINE void ZMQContext::unregisterSocket(ZMQSocket* socket_)
 {
-    Sockets::iterator soIt = m_sockets.begin();
-    while (soIt != m_sockets.end())
+    for(Sockets::iterator soIt = m_sockets.begin(); soIt != m_sockets.end(); ++soIt)
     {
         if (*soIt == socket_)
         {
             m_sockets.erase(soIt);
             break;
         }
-        ++soIt;
     }
 }
 

--- a/include/nzmqt/nzmqt.hpp
+++ b/include/nzmqt/nzmqt.hpp
@@ -76,11 +76,10 @@ namespace nzmqt
         typedef zmq::message_t super;
 
     public:
-        ZMQMessage();
+        ZMQMessage() = default;
 
-        ZMQMessage(size_t size_);
-
-        ZMQMessage(void* data_, size_t size_, free_fn *ffn_, void* hint_ = 0);
+        // Forward the constructors from the super-class as is.
+        using super::super;
 
         ZMQMessage(const QByteArray& b);
 

--- a/include/nzmqt/nzmqt.hpp
+++ b/include/nzmqt/nzmqt.hpp
@@ -87,7 +87,7 @@ namespace nzmqt
 
         void move(ZMQMessage* msg_);
 
-        void copy(ZMQMessage* msg_);
+        using super::copy;
 
         using super::more;
 

--- a/include/nzmqt/nzmqt.hpp
+++ b/include/nzmqt/nzmqt.hpp
@@ -424,13 +424,13 @@ namespace nzmqt
         int getInterval() const;
 
         // Starts the polling process by scheduling a call to the 'run()' method into Qt's event loop.
-        void start();
+        void start() override;
 
         // Stops the polling process in the sense that no further 'run()' calls will be scheduled into
         // Qt's event loop.
-        void stop();
+        void stop() override;
 
-        bool isStopped() const;
+        bool isStopped() const override;
 
     public slots:
         // If the polling process is not stopped (by a previous call to the 'stop()' method) this
@@ -451,13 +451,13 @@ namespace nzmqt
         void pollError(int errorNum, const QString& errorMsg);
 
     protected:
-        PollingZMQSocket* createSocketInternal(ZMQSocket::Type type_);
+        PollingZMQSocket* createSocketInternal(ZMQSocket::Type type_) override;
 
         // Add the given socket to list list of poll-items.
-        void registerSocket(ZMQSocket* socket_);
+        void registerSocket(ZMQSocket* socket_) override;
 
         // Remove the given socket object from the list of poll-items.
-        void unregisterSocket(ZMQSocket* socket_);
+        void unregisterSocket(ZMQSocket* socket_) override;
 
     private:
         typedef QVector<pollitem_t> PollItems;
@@ -511,11 +511,11 @@ namespace nzmqt
     public:
         SocketNotifierZMQContext(QObject* parent_ = 0, int io_threads_ = NZMQT_DEFAULT_IOTHREADS);
 
-        void start();
+        void start() override;
 
-        void stop();
+        void stop() override;
 
-        bool isStopped() const;
+        bool isStopped() const override;
 
     signals:
         // This signal will be emitted by the socket notifier callback if a call

--- a/include/nzmqt/nzmqt.hpp
+++ b/include/nzmqt/nzmqt.hpp
@@ -40,6 +40,8 @@
 #include <QRunnable>
 #include <QVector>
 
+#include <type_traits>
+
 // Define default context implementation to be used.
 #ifndef NZMQT_DEFAULT_ZMQCONTEXT_IMPLEMENTATION
     #define NZMQT_DEFAULT_ZMQCONTEXT_IMPLEMENTATION PollingZMQContext
@@ -197,13 +199,11 @@ namespace nzmqt
 
         void setOption(Option optName_, const QByteArray& bytes_);
 
-        void setOption(Option optName_, qint32 value_);
-
-        void setOption(Option optName_, quint32 value_);
-
-        void setOption(Option optName_, qint64 value_);
-
-        void setOption(Option optName_, quint64 value_);
+        template<typename INT_T, typename = typename std::enable_if<std::is_integral<INT_T>::value>::type>
+        void setOption(Option optName_, INT_T value_)
+        {
+            setOption(optName_, &value_, sizeof(value_));
+        }
 
         void getOption(Option option_, void *optval_, size_t *optvallen_) const;
 

--- a/include/nzmqt/nzmqt.hpp
+++ b/include/nzmqt/nzmqt.hpp
@@ -318,7 +318,7 @@ namespace nzmqt
         friend class ZMQSocket;
 
     public:
-        ZMQContext(QObject* parent_ = 0, int io_threads_ = NZMQT_DEFAULT_IOTHREADS);
+        ZMQContext(QObject* parent_ = nullptr, int io_threads_ = NZMQT_DEFAULT_IOTHREADS);
 
         // Deleting children is necessary, because otherwise the children are deleted after the context
         // which results in a blocking state. So we delete the children before the zmq::context_t
@@ -333,7 +333,7 @@ namespace nzmqt
         // ownership later on). Make sure, however, that the socket's parent
         // belongs to the same thread as the socket instance itself (as it is required
         // by Qt). Otherwise, you will encounter strange errors.
-        ZMQSocket* createSocket(ZMQSocket::Type type_, QObject* parent_ = 0);
+        ZMQSocket* createSocket(ZMQSocket::Type type_, QObject* parent_ = nullptr);
 
         // Start watching for incoming messages.
         virtual void start() = 0;
@@ -413,7 +413,7 @@ namespace nzmqt
         typedef ZMQContext super;
 
     public:
-        PollingZMQContext(QObject* parent_ = 0, int io_threads_ = NZMQT_DEFAULT_IOTHREADS);
+        PollingZMQContext(QObject* parent_ = nullptr, int io_threads_ = NZMQT_DEFAULT_IOTHREADS);
 
         // Sets the polling interval.
         // Note that the interval does not denote the time the zmq::poll() function will
@@ -509,7 +509,7 @@ namespace nzmqt
         typedef ZMQContext super;
 
     public:
-        SocketNotifierZMQContext(QObject* parent_ = 0, int io_threads_ = NZMQT_DEFAULT_IOTHREADS);
+        SocketNotifierZMQContext(QObject* parent_ = nullptr, int io_threads_ = NZMQT_DEFAULT_IOTHREADS);
 
         void start() override;
 
@@ -526,7 +526,7 @@ namespace nzmqt
         SocketNotifierZMQSocket* createSocketInternal(ZMQSocket::Type type_);
     };
 
-    NZMQT_API inline ZMQContext* createDefaultContext(QObject* parent_ = 0, int io_threads_ = NZMQT_DEFAULT_IOTHREADS)
+    NZMQT_API inline ZMQContext* createDefaultContext(QObject* parent_ = nullptr, int io_threads_ = NZMQT_DEFAULT_IOTHREADS)
     {
         return new NZMQT_DEFAULT_ZMQCONTEXT_IMPLEMENTATION(parent_, io_threads_);
     }


### PR DESCRIPTION
Each of the commits in this pull request should be separable form the others if you care to do so.

The purpose of this pull request is to upgrade the nzmqt codebase to take advantage of modern c++11 language features.

Please note that Qt 5.7, released 1 year ago, introduced a hard requirement of c++11 support for the compiler in use. 

Each commit has been tested in sequence (building on the previous) using the nzmqt_test program, with GCC 5.4.0.

