### PR TITLE
Trigger the messageReceived signal directly, instead of using a trampoline

### DIFF
--- a/include/nzmqt/impl.hpp
+++ b/include/nzmqt/impl.hpp
@@ -413,12 +413,6 @@ NZMQT_INLINE PollingZMQSocket::PollingZMQSocket(PollingZMQContext* context_, Typ
 {
 }
 
-NZMQT_INLINE void PollingZMQSocket::onMessageReceived(const QList<QByteArray>& message)
-{
-    emit messageReceived(message);
-}
-
-
 
 /*
  * PollingZMQContext
@@ -501,7 +495,7 @@ NZMQT_INLINE void PollingZMQContext::poll(long timeout_)
             {
                 PollingZMQSocket* socket = static_cast<PollingZMQSocket*>(*soIt);
                 QList<QByteArray> && message = socket->receiveMessage();
-                socket->onMessageReceived(std::move(message));
+                socket->messageReceived(std::move(message));
                 i++;
             }
             ++soIt;

--- a/include/nzmqt/nzmqt.hpp
+++ b/include/nzmqt/nzmqt.hpp
@@ -400,10 +400,6 @@ namespace nzmqt
 
     protected:
         PollingZMQSocket(PollingZMQContext* context_, Type type_);
-
-        // This method is called by the socket's context object in order
-        // to signal a new received message.
-        void onMessageReceived(const QList<QByteArray>& message);
     };
 
     class NZMQT_API PollingZMQContext : public ZMQContext, public QRunnable


### PR DESCRIPTION
Qt allows a signal to be called directly as if it were a function call, and the result is the same as "emit signalNameHere(args here)"

In fact, the "emit" keyword just expands to a single space as far as the c++ preprocessor is concerned. Or at least that was the case at one point. I'm pretty sure it's still the case.

This change passes the nzmqt_test app as my others do.