### PR TITLE
Revert "Explicitly use constructor from base class"

### DIFF
--- a/include/nzmqt/impl.hpp
+++ b/include/nzmqt/impl.hpp
@@ -50,6 +50,21 @@ namespace nzmqt
  * ZMQMessage
  */
 
+NZMQT_INLINE ZMQMessage::ZMQMessage()
+    : super()
+{
+}
+
+NZMQT_INLINE ZMQMessage::ZMQMessage(size_t size_)
+    : super(size_)
+{
+}
+
+NZMQT_INLINE ZMQMessage::ZMQMessage(void* data_, size_t size_, free_fn *ffn_, void* hint_)
+    : super(data_, size_, ffn_, hint_)
+{
+}
+
 NZMQT_INLINE ZMQMessage::ZMQMessage(const QByteArray& b)
     : super(b.size())
 {

--- a/include/nzmqt/nzmqt.hpp
+++ b/include/nzmqt/nzmqt.hpp
@@ -78,10 +78,11 @@ namespace nzmqt
         typedef zmq::message_t super;
 
     public:
-        ZMQMessage() = default;
+        ZMQMessage();
 
-        // Forward the constructors from the super-class as is.
-        using super::super;
+        ZMQMessage(size_t size_);
+
+        ZMQMessage(void* data_, size_t size_, free_fn *ffn_, void* hint_ = 0);
 
         ZMQMessage(const QByteArray& b);
 


### PR DESCRIPTION
This reverts commit 0cfc7041028b1e5b64c742f642bcbe34152f1db0.
Revert this due to VS2013 incompatibility.