### PR TITLE
impl.hpp - add an explicit flags cast in receiveMessage()

### DIFF
--- a/include/nzmqt/nzmqt.hpp
+++ b/include/nzmqt/nzmqt.hpp
@@ -135,7 +135,7 @@ namespace nzmqt
             TYP_XSUB = ZMQ_XSUB
         };
 
-        enum Event
+        enum Event : int
         {
             EVT_POLLIN = ZMQ_POLLIN,
             EVT_POLLOUT = ZMQ_POLLOUT,
@@ -143,14 +143,14 @@ namespace nzmqt
         };
         Q_DECLARE_FLAGS(Events, Event)
 
-        enum SendFlag
+        enum SendFlag : int
         {
             SND_MORE = ZMQ_SNDMORE,
             SND_DONTWAIT = ZMQ_DONTWAIT
         };
         Q_DECLARE_FLAGS(SendFlags, SendFlag)
 
-        enum ReceiveFlag
+        enum ReceiveFlag : int
         {
             RCV_DONTWAIT = ZMQ_DONTWAIT
         };


### PR DESCRIPTION
Some compilers like gcc 5.3 don't manage to determine the correct overload, so we need this explicit cast.

| In file included from build/release/.moc/../../../../../trunk/UI/BizMQ/nzmqt/nzmqt.hpp:553:0,
|                  from build/release/.moc/moc_nzmqt.cpp:9:
| ../../trunk/UI/BizMQ/nzmqt/impl.hpp: In member function 'bool nzmqt::ZMQSocket::receiveMessage(nzmqt::ZMQMessage*, nzmqt::ZMQSocket::ReceiveFlags)':
| ../../trunk/UI/BizMQ/nzmqt/impl.hpp:207:29: error: call of overloaded 'recv(nzmqt::ZMQMessage*&, nzmqt::ZMQSocket::ReceiveFlags&)' is ambiguous
|      return recv(msg_, flags_);
|                              ^
| In file included from build/release/.moc/../../../../../trunk/UI/BizMQ/nzmqt/nzmqt.hpp:32:0,
|                  from build/release/.moc/moc_nzmqt.cpp:9:
| ../../trunk/daemons/libs/zmq.hpp:633:23: note: candidate: size_t zmq::socket_t::recv(void*, size_t, int)
|          inline size_t recv (void *buf_, size_t len_, int flags_ = 0)
|                        ^
| ../../trunk/daemons/libs/zmq.hpp:643:21: note: candidate: bool zmq::socket_t::recv(zmq::message_t*, int)
|          inline bool recv (message_t *msg_, int flags_ = 0)
|                      ^
| Makefile:487: recipe for target 'build/release/.obj/moc_nzmqt.o' failed