### PR TITLE
Clang tidy issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,99 @@
+cmake_minimum_required(VERSION 3.8.2)
+
+project(nzmqt VERSION 3.2.1 LANGUAGES CXX)
+
+# Setup the QT5 path
+set(Qt5_DIR /opt/qt/5.15.0/lib/cmake/Qt5 CACHE PATH "Path for QT cmake")
+
+# Setup the CONFIG install path
+include(GNUInstallDirs)
+set(
+    NZMQT_CONFIG_INSTALL_DIR
+    "${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}" CACHE PATH
+    "Install path for nzmqtConfig.cmake"
+)
+
+find_package(cppzmq REQUIRED CONFIG)
+find_package(Qt5 REQUIRED COMPONENTS Core)
+
+# Needed for QT to resolve Q_OBJECT methods on link
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+#######
+# Build
+#######
+add_library(nzmqt SHARED "")
+
+target_include_directories(
+    nzmqt
+    PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+    ${cppzmq_INCLUDE_DIR}
+    ${Qt5Core_INCLUDE_DIRS}
+)
+
+target_compile_definitions(
+    nzmqt
+    PUBLIC
+    ZMQ_BUILD_DRAFT_API
+    NZMQT_LIB
+    NZMQT_SHAREDLIB
+)
+
+target_sources(
+    nzmqt
+    PRIVATE
+    src/nzmqt/nzmqt.cpp
+    include/nzmqt/global.hpp
+    include/nzmqt/impl.hpp
+    include/nzmqt/nzmqt.hpp
+)
+
+target_link_libraries(
+    nzmqt
+    PUBLIC
+    cppzmq
+    Qt5::Core
+)
+
+#########
+# Install
+#########
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+    ${PROJECT_NAME}Config.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    INSTALL_DESTINATION ${NZMQT_CONFIG_INSTALL_DIR}
+)
+
+install(
+    DIRECTORY include/nzmqt
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(
+    TARGETS nzmqt
+    EXPORT ${PROJECT_NAME}-targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+    DESTINATION ${NZMQT_CONFIG_INSTALL_DIR}
+)
+
+export(
+    EXPORT ${PROJECT_NAME}-targets
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake"
+)
+
+install(
+    EXPORT ${PROJECT_NAME}-targets
+    FILE ${PROJECT_NAME}Targets.cmake
+    DESTINATION ${NZMQT_CONFIG_INSTALL_DIR}
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ add_library(nzmqt SHARED "")
 target_include_directories(
     nzmqt
     PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
     ${cppzmq_INCLUDE_DIR}
     ${Qt5Core_INCLUDE_DIRS}

--- a/include/nzmqt/nzmqt.hpp
+++ b/include/nzmqt/nzmqt.hpp
@@ -373,7 +373,7 @@ namespace nzmqt
         // Remove the given socket object from the list of registered sockets.
         virtual void unregisterSocket(ZMQSocket* socket_);
 
-        virtual const Sockets& registeredSockets() const;
+        const Sockets& registeredSockets() const;
 
     private:
         Sockets m_sockets;

--- a/include/nzmqt/nzmqt.hpp
+++ b/include/nzmqt/nzmqt.hpp
@@ -204,7 +204,7 @@ namespace nzmqt
 #endif
         };
 
-        ~ZMQSocket();
+        virtual ~ZMQSocket();
 
         using zmqsuper::operator void *;
 
@@ -338,7 +338,7 @@ namespace nzmqt
         // Deleting children is necessary, because otherwise the children are deleted after the context
         // which results in a blocking state. So we delete the children before the zmq::context_t
         // destructor implementation is called.
-        ~ZMQContext();
+        virtual ~ZMQContext();
 
         using zmqsuper::operator void*;
 

--- a/include/nzmqt/nzmqt.hpp
+++ b/include/nzmqt/nzmqt.hpp
@@ -177,6 +177,7 @@ namespace nzmqt
 #ifdef ZMQ_REQ_RELAXED
             OPT_REQ_RELAXED = ZMQ_REQ_RELAXED,
 #endif
+            OPT_LAST_ENDPOINT = ZMQ_LAST_ENDPOINT,
 
             // Get and set.
             OPT_AFFINITY = ZMQ_AFFINITY,

--- a/include/nzmqt/nzmqt.hpp
+++ b/include/nzmqt/nzmqt.hpp
@@ -309,6 +309,8 @@ namespace nzmqt
         // If an empty list is provided this method doesn't do anything and returns trua.
         bool sendMessage(const QList<QByteArray>& msg_, nzmqt::ZMQSocket::SendFlags flags_ = SND_DONTWAIT);
 
+        // Slot called internally to query the events() flags from the event loop after a sendMessage call.
+        void checkEvents();
 
     protected:
         ZMQSocket(ZMQContext* context_, Type type_);

--- a/include/nzmqt/nzmqt.hpp
+++ b/include/nzmqt/nzmqt.hpp
@@ -506,11 +506,9 @@ namespace nzmqt
 
     protected slots:
         void socketReadActivity();
-        void socketWriteActivity();
 
     private:
         QSocketNotifier *socketNotifyRead_;
-        QSocketNotifier *socketNotifyWrite_;
     };
 
     class NZMQT_API SocketNotifierZMQContext : public ZMQContext

--- a/nzmqtConfig.cmake.in
+++ b/nzmqtConfig.cmake.in
@@ -1,0 +1,21 @@
+# nzmqt cmake module
+#
+# The following import targets are created
+# ::nzmqt
+#
+# This module sets the following variables in your project::
+#
+# nzmqt_FOUND - true if nzmqt found on the system
+# nzmqt_INCLUDE_DIRS - the directories containing nzmqt headers
+# nzmqt_LIBRARIES - the libraries needed for dynamic linking
+set(nzmqt_VERSION 3.2.1)
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_package(cppzmq REQUIRED)
+find_package(Qt5 REQUIRED COMPONENTS Core)
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+get_target_property(nzmqt_INCLUDE_DIRS nzmqt INTERFACE_INCLUDE_DIRECTORIES)
+get_target_property(_nzmqt_shared_libs nzmqt INTERFACE_LINK_LIBRARIES)
+list(APPEND nzmqt_LIBRARIES nzmqt ${_nzmqt_shared_libs})


### PR DESCRIPTION
Remove virtual from registeredSockets function since it is invoked in the destructor.

I will create a PR in third-party once this has been approved. 