### PR TITLE
Fix build with Qt 6

### DIFF
--- a/include/nzmqt/impl.hpp
+++ b/include/nzmqt/impl.hpp
@@ -435,7 +435,9 @@ NZMQT_INLINE PollingZMQSocket::PollingZMQSocket(PollingZMQContext* context_, Typ
 
 NZMQT_INLINE PollingZMQContext::PollingZMQContext(QObject* parent_, int io_threads_)
     : super(parent_, io_threads_)
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     , m_pollItemsMutex(QMutex::Recursive)
+#endif
     , m_interval(NZMQT_POLLINGZMQCONTEXT_DEFAULT_POLLINTERVAL)
     , m_stopped(false)
 {

--- a/include/nzmqt/nzmqt.hpp
+++ b/include/nzmqt/nzmqt.hpp
@@ -474,7 +474,11 @@ namespace nzmqt
         typedef QVector<pollitem_t> PollItems;
 
         PollItems m_pollItems;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        QRecursiveMutex m_pollItemsMutex;
+#else
         QMutex m_pollItemsMutex;
+#endif
         int m_interval;
         volatile bool m_stopped;
     };

--- a/include/nzmqt/nzmqt.hpp
+++ b/include/nzmqt/nzmqt.hpp
@@ -447,7 +447,7 @@ namespace nzmqt
         // If the polling process is not stopped (by a previous call to the 'stop()' method) this
         // method will call the 'poll()' method once and re-schedule a subsequent call to this method
         // using the current polling interval.
-        void run();
+        void run() override;
 
         // This method will poll on all currently available poll-items (known ZMQ sockets)
         // using the given timeout to wait for incoming messages. Note that this timeout has
@@ -538,7 +538,7 @@ namespace nzmqt
         void notifierError(int errorNum, const QString& errorMsg);
 
     protected:
-        SocketNotifierZMQSocket* createSocketInternal(ZMQSocket::Type type_);
+        SocketNotifierZMQSocket* createSocketInternal(ZMQSocket::Type type_) override;
     };
 
     NZMQT_API inline ZMQContext* createDefaultContext(QObject* parent_ = nullptr, int io_threads_ = NZMQT_DEFAULT_IOTHREADS)


### PR DESCRIPTION
QMutex::Recursive was deprecated in 15.4 and dropped from Qt 6.